### PR TITLE
Make sure sections aren't too large before doing an allocation

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -91,7 +91,7 @@ func readSection(r io.Reader, sSize int, maxSize uint64) (data []byte, nr io.Rea
 	// Create a []byte of sectionSize-4 and read that many bytes from io.Reader.
 	computedSize := sectionSize - uint64(sSize)
 	if computedSize > maxSize {
-		return data, nr, size, fmt.Errorf("golnk.readSection: invalid computed size got %d; expected a size < %d", sSize, maxSize)
+		return data, nr, size, fmt.Errorf("golnk.readSection: invalid computed size got %d; expected a size < %d", computedSize, maxSize)
 	}
 
 	tempData := make([]byte, computedSize)

--- a/bytes.go
+++ b/bytes.go
@@ -52,7 +52,7 @@ func ReadBytes(b []byte, offset, num int) (out []byte, n int) {
 	The size bytes are added to the start of the []byte to keep the section
 	[]byte intact for later offset use.
 */
-func readSection(r io.Reader, sSize int) (data []byte, nr io.Reader, size int, err error) {
+func readSection(r io.Reader, sSize int, maxSize uint64) (data []byte, nr io.Reader, size int, err error) {
 	// We are not going to lose data by copying a smaller var into a larger one.
 	var sectionSize uint64
 	switch sSize {
@@ -89,7 +89,12 @@ func readSection(r io.Reader, sSize int) (data []byte, nr io.Reader, size int, e
 	}
 
 	// Create a []byte of sectionSize-4 and read that many bytes from io.Reader.
-	tempData := make([]byte, sectionSize-uint64(sSize))
+	computedSize := sectionSize - uint64(sSize)
+	if computedSize > maxSize {
+		return data, nr, size, fmt.Errorf("golnk.readSection: invalid computed size got %d; expected a size < %d", sSize, maxSize)
+	}
+
+	tempData := make([]byte, computedSize)
 	err = binary.Read(r, binary.LittleEndian, &tempData)
 	if err != nil {
 		return data, nr, size, fmt.Errorf("golnk.readSection: read section %d bytes - %s", sectionSize-uint64(sSize), err.Error())

--- a/file.go
+++ b/file.go
@@ -16,9 +16,9 @@ type LnkFile struct {
 }
 
 // Read parses an io.Reader pointing to the contents of an lnk file.
-func Read(r io.Reader) (f LnkFile, err error) {
+func Read(r io.Reader, maxSize uint64) (f LnkFile, err error) {
 
-	f.Header, err = Header(r)
+	f.Header, err = Header(r, maxSize)
 	if err != nil {
 		return f, fmt.Errorf("golnk.Read: parse Header - %s", err.Error())
 	}
@@ -33,7 +33,7 @@ func Read(r io.Reader) (f LnkFile, err error) {
 
 	// If HasLinkInfo is set, read LinkInfo section.
 	if f.Header.LinkFlags["HasLinkInfo"] {
-		f.LinkInfo, err = LinkInfo(r)
+		f.LinkInfo, err = LinkInfo(r, maxSize)
 		if err != nil {
 			return f, fmt.Errorf("golnk.Read: parse LinkInfo - %s", err.Error())
 		}
@@ -61,5 +61,14 @@ func File(filename string) (f LnkFile, err error) {
 	}
 	defer fi.Close()
 
-	return Read(fi)
+	// To try and detect malformed lnk files, we'll make sure no section is bigger than the actual file size as that
+	// shouldn't ever happen
+	maxSize := uint64(1 << 22)
+	if s, err := fi.Stat(); err == nil {
+		if maxSize > 0 {
+			maxSize = uint64(s.Size())
+		}
+	}
+
+	return Read(fi, maxSize)
 }

--- a/header.go
+++ b/header.go
@@ -93,10 +93,10 @@ var fileAttributesFlags = []string{
 }
 
 // Header parses the first 0x4c bytes of the io.Reader and returns a ShellLinkHeader.
-func Header(r io.Reader) (head ShellLinkHeaderSection, err error) {
+func Header(r io.Reader, maxSize uint64) (head ShellLinkHeaderSection, err error) {
 
 	// Read the section.
-	sectionData, sectionReader, sectionSize, err := readSection(r, 4)
+	sectionData, sectionReader, sectionSize, err := readSection(r, 4, maxSize)
 	if err != nil {
 		return head, fmt.Errorf("lnk.header: error reading magic string - %s", err.Error())
 	}

--- a/linkinfo.go
+++ b/linkinfo.go
@@ -95,10 +95,10 @@ var linkInfoFlags = []string{
 }
 
 // LinkInfo reads the io.Reader and returns a populated LinkInfoSection.
-func LinkInfo(r io.Reader) (info LinkInfoSection, err error) {
+func LinkInfo(r io.Reader, maxSize uint64) (info LinkInfoSection, err error) {
 
 	// Parse section.
-	sectionData, sectionReader, sectionSize, err := readSection(r, 4)
+	sectionData, sectionReader, sectionSize, err := readSection(r, 4, maxSize)
 	if err != nil {
 		return info, fmt.Errorf("lnk.LinkInfo: section - %s", err.Error())
 	}
@@ -193,7 +193,7 @@ func LinkInfo(r io.Reader) (info LinkInfoSection, err error) {
 		// Read VolumeID struct from offset.
 		// Make an io.Reader for bytes starting from that offset.
 		vbuf := bytes.NewReader(sectionData[info.VolumeIDOffset:])
-		vol, err := VolumeID(vbuf)
+		vol, err := VolumeID(vbuf, maxSize)
 		if err != nil {
 			return info, fmt.Errorf("lnk.LinkInfo: parse VolumeID - %s", err.Error())
 		}
@@ -250,7 +250,7 @@ func LinkInfo(r io.Reader) (info LinkInfoSection, err error) {
 			// Create a reader from CommonNetworkRelativeLink data.
 			nbuf := bytes.NewReader(sectionData[info.CommonNetworkRelativeLinkOffset:])
 			// And parse it.
-			info.NetworkRelativeLink, _ = CommonNetwork(nbuf)
+			info.NetworkRelativeLink, _ = CommonNetwork(nbuf, maxSize)
 		}
 	}
 	return info, err

--- a/linkinfo_network.go
+++ b/linkinfo_network.go
@@ -118,9 +118,9 @@ func networkProviderType(index uint32) string {
 
 // CommonNetwork reads the section data and populates a CommonNetworkRelativeLink.
 // Section 2.3.2 in docs.
-func CommonNetwork(r io.Reader) (c CommonNetworkRelativeLink, err error) {
+func CommonNetwork(r io.Reader, maxSize uint64) (c CommonNetworkRelativeLink, err error) {
 	// Read the section.
-	sectionData, sectionReader, sectionSize, err := readSection(r, 4)
+	sectionData, sectionReader, sectionSize, err := readSection(r, 4, maxSize)
 	if err != nil {
 		return c, fmt.Errorf("golnk.CommonNetwork: read CommonNetwork section - %s", err.Error())
 	}

--- a/linkinfo_volumeid.go
+++ b/linkinfo_volumeid.go
@@ -47,9 +47,9 @@ var driveType = []string{
 }
 
 // VolumeID reads the VolID struct.
-func VolumeID(r io.Reader) (v VolID, err error) {
+func VolumeID(r io.Reader, maxSize uint64) (v VolID, err error) {
 	// Read the section.
-	sectionData, sectionReader, sectionSize, err := readSection(r, 4)
+	sectionData, sectionReader, sectionSize, err := readSection(r, 4, maxSize)
 	if err != nil {
 		return v, fmt.Errorf("golnk.VolumeID: read VolumeID section - %s", err.Error())
 	}


### PR DESCRIPTION
There are some lnk files I've come across that must be corrupt or something because the readSection function is trying to allocate an array of size 392,634,368 and panic-ing due to running out of memory.

* `runtime: out of memory: cannot allocate 392634368-byte block (805109760 in use)`
* `C:/devel/go/src/[snip]/vendor/github.com/parsiya/golnk/bytes.go:92`

I figured we could check how big the lnk file is itself and if any section claims it's bigger than that, we can safely assume it is corrupt and bail out.  Alternatively instead of passing around the max size everywhere you could just use a hard-coded max value.  If we can't get the size of the lnk file for whatever reason I just fallback to 4mb which seems more than we should ever encounter.